### PR TITLE
delete node from BST feature

### DIFF
--- a/include/bst.h
+++ b/include/bst.h
@@ -11,8 +11,11 @@
 class BST
 {
 private:
+	int cur_id;
 	void insertNode(Node* target, int value = 0); 
+
 public: 
+	Node** findDeepestLeftChild(Node** cur) const; // <-- The SMALLEST node in the right subtree 
 	Node* root; 
 	size_t size;
 
@@ -20,8 +23,10 @@ public:
 	inline void insert(int value) { insertNode(this->root, value); }
 
 	void getAllLeaves(std::vector<Node*>* leaves, Node* cur) const;
-	void searchNodeById(int id, Node** ptr, Node* cur) const;
-	
+	Node** searchNodeById(int id, Node** cur) const;
+	bool deleteNodeById(int id); 
+	// void deleteNodeByPtr(Node* n) <- Need to verify if "n" is part of tree (it's inside this->root)
+
 	void print(Node* n, std::string prefix = "", bool is_left = false, int depth = 0); // include depth too
 };
 
@@ -30,7 +35,6 @@ public:
  * - [x] Search all leaves 
  * - [ ] Delete a given Node  
  * - [ ] ...
- * 
  */
 
 #endif

--- a/include/node.h
+++ b/include/node.h
@@ -6,7 +6,7 @@ class Node
 public: 
 	Node* right; 
 	Node* left; 
-	Node* parent; 
+	Node* parent;
 
 	int id; 
 	int value;
@@ -20,11 +20,17 @@ public:
 	{;}
 
 	inline const bool isEmpty() const;
+	inline const bool isFull() const; 
 };
 
 inline const bool Node::isEmpty() const
 {
 	return (this->right == nullptr && this->left == nullptr);
+}
+
+inline const bool Node::isFull() const 
+{
+	return (this->right != nullptr && this->left != nullptr); // this differ Node::isEmpty() 
 }
 
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -4,30 +4,39 @@
 
 #include "include/bst.h"
 
+BST* generateRandomBST(int init_value, int min, int max); 
+
 int main(void)
 {	
-	std::vector<int> values; 
-	std::random_device rd; 
+	BST* tree = generateRandomBST(20, 10, 30); 
 
-	BST tree(20); 
+	tree->print(tree->root);
+	printf("\n\n");
 	
-	for (int i = 0; i <= 20; i++)
-		values.push_back(i);
+	tree->deleteNodeById(0);
 
-	std::shuffle(values.begin(), values.end(), std::default_random_engine(rd())); 
-
-	for (int i : values)
-		tree.insert(i);
-
-	//tree.print(tree.root); 
-	
-	Node* test = nullptr;
-
-	tree.searchNodeById(40, &test, tree.root);
-	
-	if (test != nullptr)
-		printf("\nn value: %i, n id: %i\n", test->value, test->id);
+	printf("\n\n");
+	tree->print(tree->root);
 
 	return 0; 
 }
 
+BST* generateRandomBST(int init_value, int min, int max) 
+{
+	BST* bst = new BST(init_value);
+
+	if (min >= max) return nullptr; 
+
+	std::vector<int> values; 
+	std::random_device rd; 
+
+	for (int i = min; i <= max; i++)
+		values.push_back(i);
+
+	std::shuffle(values.begin(), values.end(), std::default_random_engine(rd())); 
+
+	for (int v : values)
+		bst->insert(v);
+
+	return bst;
+}

--- a/src/bst.cpp
+++ b/src/bst.cpp
@@ -1,4 +1,5 @@
 #include "../include/bst.h"
+#include <algorithm>
 
 void BST::insertNode(Node* target, int value) 
 {
@@ -7,20 +8,14 @@ void BST::insertNode(Node* target, int value)
 	if (value <= target->value) 
 	{
 		if (target->left == nullptr)
-		{
-			this->size++; 
-			target->left = new Node(size, value, target);
-		}
+			target->left = new Node(++this->cur_id, value, target);
 		else
 			insertNode(target->left, value);
 	}
 	else 
 	{
 		if (target->right == nullptr)
-		{
-			this->size++;
-			target->right = new Node(size, value, target);
-		}
+			target->right = new Node(++this->cur_id, value, target);
 		else 
 			insertNode(target->right, value);	
 	}
@@ -34,10 +29,12 @@ void BST::print(Node* n, std::string prefix, bool is_left, int depth)
 	{
 		bool parent_has_left = n->parent->left == nullptr; 
 		
-		printf(is_left || parent_has_left ? "%s└── %i [%i]\n" : "%s├── %i [%i]\n", prefix.c_str(), n->value, n->id);
+		printf(is_left || parent_has_left ? "%s└── %i" : "%s├── %i", prefix.c_str(), n->value);
 		prefix += !is_left && !parent_has_left ? "│   " : "    ";
+	
+		is_left ? printf(" L\n") : printf(" R\n");
 	}
-	else printf("%i [%i]\n", n->value, n->id);
+	else printf("%i ROOT\n", n->value);
 
 	print(n->right, prefix, false, depth + 1);
 	print(n->left, prefix, true, depth + 1);
@@ -54,16 +51,80 @@ void BST::getAllLeaves(std::vector<Node*>* leaves, Node* cur) const
 	getAllLeaves(leaves, cur->right); 
 }
 
-void BST::searchNodeById(int id, Node** ptr, Node* cur) const
+Node** BST::searchNodeById(int id, Node** cur) const
 {
-	if (cur == nullptr) return; 
+	if (*cur == nullptr) return nullptr; 
 
-	if (cur->id == id) 
+	if ((*cur)->id == id) 
+		return cur;
+
+	Node** left_result = searchNodeById(id, &(*cur)->left); 
+	
+	if (left_result != nullptr) 
+		return left_result; 
+
+	return searchNodeById(id, &(*cur)->right); 
+}
+
+Node** BST::findDeepestLeftChild(Node** cur) const 
+{
+	if (cur == nullptr) return nullptr; // <- is it necessary? 
+
+	if ((*cur)->left == nullptr)
+		return cur; 
+
+	return findDeepestLeftChild(&(*cur)->left); 
+}
+
+bool BST::deleteNodeById(int id) 
+{
+	Node** n = this->searchNodeById(id, &this->root);
+	if (n == nullptr) return false;
+	
+	if ((*n)->isEmpty())
 	{
-		*ptr = cur; 
-		return;
+		delete *n;
+		*n = nullptr; // avoid dangling ptr
+		this->size--; 
+		return true;	
 	}
 
-	searchNodeById(id, ptr, cur->left);
-	searchNodeById(id, ptr, cur->right);
+	if ((*n)->isFull())
+	{
+		/* NOTE
+		 * This solution kinda sucks. Find a 
+		 * way to avoid using id_buf. 
+		**/
+
+		Node** successor = findDeepestLeftChild(&(*n)->right);	
+		int id_buf = (*successor)->id;
+
+		(*n)->value = (*successor)->value;
+		(*n)->parent = (*successor)->parent;
+
+		deleteNodeById((*successor)->id);
+		
+		(*n)->id = id_buf;
+		
+		this->size--;
+		return true; 
+	}
+
+	if ((*n)->left != nullptr) // has left node
+	{ // dangling ptr here? 
+		(*n)->left->parent = (*n)->parent; 
+		*n = (*n)->left;
+		this->size--; 
+		return true; 
+	}
+
+	if ((*n)->right != nullptr) // has right node
+	{
+		(*n)->right->parent = (*n)->parent;
+		*n = (*n)->right; 
+		this->size--;
+		return true; 
+	}
+
+	return true; 
 }


### PR DESCRIPTION
## Delete Node Feature

This version of the Binary Search Tree study implements deleting a Node using it's ID (`Node::id<int>`). Function: `bool BST::deleteNodeById(int id)`. 

In future, I will implement `bool BST::deleteNode(Node* node)` . 

Maybe structuring these functions like the `BST::insertNode(Node* root, int value)` **(private)** and `BST::insert(int value)` **(public)**. 